### PR TITLE
Added support for Msg and Confirm functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5146,12 +5146,12 @@
       "dev": true
     },
     "standard-api-generator": {
-      "version": "git+https://github.com/genexuslabs/standard-api-generator.git#11d4e56693b082b183bae8ce0611e0a1ac118d37",
+      "version": "git+https://github.com/genexuslabs/standard-api-generator.git#5a74e18380e94fcb216c0b3b1300d9d99951ca95",
       "from": "git+https://github.com/genexuslabs/standard-api-generator.git",
       "dev": true,
       "requires": {
         "cli": "^1.0.1",
-        "handlebars": "^4.1.0"
+        "handlebars": "^4.1.2"
       }
     },
     "static-extend": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "env-cmd": "^8.0.2",
     "husky": "^2.4.0",
     "jest": "^24.8.0",
-    "wait-for-expect": "^1.2.0",
     "prettier": "^1.16.4",
     "pretty-quick": "^1.10.0",
     "shx": "^0.3.2",
@@ -58,7 +57,8 @@
     "tslint": "^5.17.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-config-standard": "^8.0.1",
-    "typescript": "^3.4.1"
+    "typescript": "^3.4.1",
+    "wait-for-expect": "^1.2.0"
   },
   "dependencies": {
     "bignumber.js": "^7.2.1",

--- a/src/generator/options.json
+++ b/src/generator/options.json
@@ -80,6 +80,11 @@
           "path": "./math/mod",
           "name": "mod"
         },
+        "Msg": {
+          "path": "./misc/msg",
+          "name": "msg",
+          "notifiesGenerator": true
+        },
         "NewLine": {
           "path": "./text/newline",
           "name": "newLine"

--- a/src/generator/options.json
+++ b/src/generator/options.json
@@ -32,6 +32,11 @@
           "path": "./text/concat",
           "name": "concat"
         },
+        "Confirm": {
+          "path": "./misc/confirm",
+          "name": "confirm",
+          "notifiesGenerator": true
+        },
         "Format": {
           "path": "./text/format",
           "name": "format"

--- a/src/misc/confirm.ts
+++ b/src/misc/confirm.ts
@@ -1,0 +1,19 @@
+import { publish, subscribe } from "../pubSub/pubSub";
+import { stdToGeneratorPublishedMessage as prefix } from "./helpers";
+
+/**
+ * Displays a message that allows capturing end user confirmation
+ * @param {string} message The message to be displayed
+ * @return boolean
+ */
+export const confirm = async (str: string): Promise<boolean> => {
+  return new Promise<boolean>(resolve => {
+    subscribe(`${prefix}.confirm.ok`, () => {
+      resolve(true);
+    });
+    subscribe(`${prefix}.confirm.cancel`, () => {
+      resolve(false);
+    });
+    publish(`${prefix}.confirm`, str);
+  });
+};

--- a/src/misc/confirm.ts
+++ b/src/misc/confirm.ts
@@ -1,5 +1,6 @@
-import { publish, subscribe } from "../pubSub/pubSub";
+import { publish, subscribe, cancelSubscription } from "../pubSub/pubSub";
 import { stdToGeneratorPublishedMessage as prefix } from "./helpers";
+import { unSubscribe } from "../web/globalEvents";
 
 /**
  * Displays a message that allows capturing end user confirmation
@@ -8,12 +9,18 @@ import { stdToGeneratorPublishedMessage as prefix } from "./helpers";
  */
 export const confirm = async (str: string): Promise<boolean> => {
   return new Promise<boolean>(resolve => {
-    subscribe(`${prefix}.confirm.ok`, () => {
+    let sOk = subscribe(`${prefix}.confirm.ok`, () => {
+      unsubscribe();
       resolve(true);
     });
-    subscribe(`${prefix}.confirm.cancel`, () => {
+    let sCancel = subscribe(`${prefix}.confirm.cancel`, () => {
+      unsubscribe();
       resolve(false);
     });
+    let unsubscribe = () => {
+      cancelSubscription(sOk);
+      cancelSubscription(sCancel);
+    };
     publish(`${prefix}.confirm`, str);
   });
 };

--- a/src/misc/helpers.ts
+++ b/src/misc/helpers.ts
@@ -5,3 +5,6 @@ export function notImplemented() {
 export function notSupported() {
   console.log("Function or method not supported");
 }
+
+export const stdToGeneratorPublishedMessage: string =
+  "gx-standard-api-to-generator";

--- a/src/misc/msg.ts
+++ b/src/misc/msg.ts
@@ -1,0 +1,6 @@
+import { publish } from "../pubSub/pubSub";
+import { stdToGeneratorPublishedMessage as prefix } from "./helpers";
+
+export const msg = (str: string, mode: string = "") => {
+  publish(`${prefix}.msg`, str, mode);
+};

--- a/src/misc/msg.ts
+++ b/src/misc/msg.ts
@@ -1,6 +1,11 @@
 import { publish } from "../pubSub/pubSub";
 import { stdToGeneratorPublishedMessage as prefix } from "./helpers";
 
+/**
+ * Displays a message to the user
+ * @param {string} message The message to be displayed
+ * @param {string} mode Optional parameter. There are two modes to display the message: `nowait` and `status`
+ */
 export const msg = (str: string, mode: string = "") => {
   publish(`${prefix}.msg`, str, mode);
 };

--- a/src/misc/test/confirm.spec.ts
+++ b/src/misc/test/confirm.spec.ts
@@ -8,7 +8,7 @@ describe("confirm test", () => {
       publish(`${prefix}.confirm.ok`);
     }, 1000);
 
-    let result = await confirm("Confrim?");
+    let result = await confirm("Confirm?");
     expect(result).toBeTruthy();
   });
   it("should return false when canceled", async () => {

--- a/src/misc/test/confirm.spec.ts
+++ b/src/misc/test/confirm.spec.ts
@@ -1,0 +1,22 @@
+import { confirm } from "../confirm";
+import { publish } from "../../pubSub/pubSub";
+import { stdToGeneratorPublishedMessage as prefix } from "../helpers";
+
+describe("confirm test", () => {
+  it("should return true when confirmed", async () => {
+    setTimeout(() => {
+      publish(`${prefix}.confirm.ok`);
+    }, 1000);
+
+    let result = await confirm("Confrim?");
+    expect(result).toBeTruthy();
+  });
+  it("should return false when canceled", async () => {
+    setTimeout(() => {
+      publish(`${prefix}.confirm.cancel`);
+    }, 1000);
+
+    let result = await confirm("Confrim?");
+    expect(result).toBeFalsy();
+  });
+});

--- a/src/misc/test/confirm.spec.ts
+++ b/src/misc/test/confirm.spec.ts
@@ -1,5 +1,5 @@
 import { confirm } from "../confirm";
-import { publish } from "../../pubSub/pubSub";
+import { publish, subscribe, cancelSubscription } from "../../pubSub/pubSub";
 import { stdToGeneratorPublishedMessage as prefix } from "../helpers";
 
 describe("confirm test", () => {
@@ -7,6 +7,12 @@ describe("confirm test", () => {
     setTimeout(() => {
       publish(`${prefix}.confirm.ok`);
     }, 1000);
+
+    let confSubscription = subscribe(`${prefix}.confirm`, (...data: any[]) => {
+      expect(data.length).toBe(1);
+      expect(data[0]).toEqual("Confirm?");
+      cancelSubscription(confSubscription);
+    });
 
     let result = await confirm("Confirm?");
     expect(result).toBe(true);
@@ -16,7 +22,13 @@ describe("confirm test", () => {
       publish(`${prefix}.confirm.cancel`);
     }, 1000);
 
-    let result = await confirm("Confrim?");
+    let confSubscription = subscribe(`${prefix}.confirm`, (...data: any[]) => {
+      expect(data.length).toBe(1);
+      expect(data[0]).toEqual("Confirm?");
+      cancelSubscription(confSubscription);
+    });
+
+    let result = await confirm("Confirm?");
     expect(result).toBe(false);
   });
 });

--- a/src/misc/test/confirm.spec.ts
+++ b/src/misc/test/confirm.spec.ts
@@ -9,7 +9,7 @@ describe("confirm test", () => {
     }, 1000);
 
     let result = await confirm("Confirm?");
-    expect(result).toBeTruthy();
+    expect(result).toBe(true);
   });
   it("should return false when canceled", async () => {
     setTimeout(() => {
@@ -17,6 +17,6 @@ describe("confirm test", () => {
     }, 1000);
 
     let result = await confirm("Confrim?");
-    expect(result).toBeFalsy();
+    expect(result).toBe(false);
   });
 });

--- a/src/misc/test/msg.spec.ts
+++ b/src/misc/test/msg.spec.ts
@@ -1,0 +1,8 @@
+import { msg } from "../msg";
+import { publish } from "../../pubSub/pubSub";
+
+describe("msg test", () => {
+  it("should work", async () => {
+    msg("Hello world!");
+  });
+});

--- a/src/misc/test/msg.spec.ts
+++ b/src/misc/test/msg.spec.ts
@@ -1,8 +1,15 @@
 import { msg } from "../msg";
-import { publish } from "../../pubSub/pubSub";
+import { subscribe, cancelSubscription } from "../../pubSub/pubSub";
+import { stdToGeneratorPublishedMessage as prefix } from "../helpers";
 
 describe("msg test", () => {
   it("should work", async () => {
+    let msgSubscription = subscribe(`${prefix}.msg`, (...data: any[]) => {
+      expect(data.length).toBe(1);
+      expect(data[0]).toEqual("Hello world!");
+      cancelSubscription(msgSubscription);
+    });
+
     msg("Hello world!");
   });
 });


### PR DESCRIPTION
### Implementation notes

Msg and Confirm functions use a publish mechanism to notify the generator that should handle de display of corresponding user interface elements.

Also, the Confirm function subscribes to the response from the generator to be able to return the result.

All published message have a common prefix, `gx-standard-api-to-generator`, followed by the function's name (in lowercase). That is, the message published by the Msg function is `gx-standard-api-to-generator.msg` and the one published by the Confirm function is `gx-standard-api-to-generator.confirm`.

The Msg function returns immediately after publishing the message.

The Confirm function waits for a `gx-standard-api-to-generator.confirm.ok` or `gx-standard-api-to-generator.confirm.cancel` message to be published to continue its execution.