### PR TITLE
#Fix: npm WARN jest-websocket-mock@1.5.0 requires a peer of mock-sock…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1879,14 +1879,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1901,20 +1899,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2031,8 +2026,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2044,7 +2038,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2059,7 +2052,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2067,14 +2059,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2093,7 +2083,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2174,8 +2163,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2187,7 +2175,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2309,7 +2296,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2390,9 +2376,9 @@
       },
       "dependencies": {
         "icu4c-data": {
-          "version": "0.64.2",
-          "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
-          "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ=="
+          "version": "0.62.2",
+          "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.62.2.tgz",
+          "integrity": "sha512-XeGQzD3LAFprTRJ+IJZky7gUEk330neU8oo+xUT7LH08JFLTC1Eh22LiyrKIJPiZKV3w5Nq/cj8QyFWe18VDtw=="
         }
       }
     },
@@ -2706,11 +2692,6 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
-    },
-    "icu4c-data": {
-      "version": "0.62.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.62.2.tgz",
-      "integrity": "sha512-XeGQzD3LAFprTRJ+IJZky7gUEk330neU8oo+xUT7LH08JFLTC1Eh22LiyrKIJPiZKV3w5Nq/cj8QyFWe18VDtw=="
     },
     "ignore": {
       "version": "3.3.10",
@@ -3935,12 +3916,12 @@
       }
     },
     "mock-socket": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.0.0.tgz",
-      "integrity": "sha512-8Q3y/chmcYRJ6oxhAO9QJwSr6ZWU2zuzD0A7tHa0HOyL83nInIqimFWuke7936IYjEuhBaOrruV+aemlB1f+aA==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-8.0.5.tgz",
+      "integrity": "sha512-dE2EbcxJKQCeYLZSsI7BAiMZCe/bHbJ2LHb5aGwUuDmfoOINEJ8QI6qYJ85NHsSNkNa90F3s6onZcmt/+MppFA==",
       "dev": true,
       "requires": {
-        "url-parse": "^1.4.4"
+        "url-parse": "^1.2.0"
       }
     },
     "mri": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "husky": "^2.4.0",
     "jest": "^24.8.0",
     "jest-websocket-mock": "^1.5.0",
-    "mock-socket": "^9.0.0",
+    "mock-socket": "~8.0",
     "prettier": "^1.16.4",
     "pretty-quick": "^1.10.0",
     "shx": "^0.3.2",


### PR DESCRIPTION
…et@~8.0 but none is installed. You must install peer dependencies yourself.