### PR TITLE
Rename window references to global

### DIFF
--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -1,0 +1,3 @@
+const globalAny = global as any;
+
+export const storage = globalAny.localStorage;

--- a/src/config/configurationState.ts
+++ b/src/config/configurationState.ts
@@ -104,11 +104,15 @@ export class ConfigurationState {
 
   // Local storage
   private getStoredValueWithKey(storagekey: string): string {
-    return window.localStorage.getItem(storagekey);
+    if (global) {
+      return global.localStorage?.getItem(storagekey);
+    }
   }
 
   private setStoredValueWithKey(storagekey: string, value: string) {
-    window.localStorage.setItem(storagekey, value);
+    if (global) {
+      global.localStorage?.setItem(storagekey, value);
+    }
   }
 
   // Static storage

--- a/src/config/configurationState.ts
+++ b/src/config/configurationState.ts
@@ -1,13 +1,14 @@
+import {
+  detect as timezoneDetect,
+  storageKey as timezoneStorageKey
+} from "../datetime/timezone";
+import { storage } from "../common/storage";
+
 const keyPrefix: string = "gx.config.configurationstate";
 const keyDynPtyPrefix: string = "gx.config.configurationstate.dynpty";
 const languageKey: string = "language";
 const validLanguagesKey: string = "languages";
 const defaultLanguageKey: string = "DEFAULT_LANGUAGE";
-
-import {
-  detect as timezoneDetect,
-  storageKey as timezoneStorageKey
-} from "../datetime/timezone";
 
 export class ConfigurationState {
   // Singleton
@@ -104,15 +105,11 @@ export class ConfigurationState {
 
   // Local storage
   private getStoredValueWithKey(storagekey: string): string {
-    if (global) {
-      return global.localStorage?.getItem(storagekey);
-    }
+    return storage?.getItem(storagekey);
   }
 
   private setStoredValueWithKey(storagekey: string, value: string) {
-    if (global) {
-      global.localStorage?.setItem(storagekey, value);
-    }
+    storage?.setItem(storagekey, value);
   }
 
   // Static storage

--- a/src/gxcore/client/client-storage/clear.ts
+++ b/src/gxcore/client/client-storage/clear.ts
@@ -4,6 +4,9 @@ import { storage, keyPrefix } from "./common";
  * Clears all pairs of key-values stored in the device
  */
 export function clear() {
+  if (!storage) {
+    return;
+  }
   for (let i = storage.length - 1; i >= 0; i--) {
     let key = storage.key(i);
     if (key.startsWith(keyPrefix)) {

--- a/src/gxcore/client/client-storage/common.ts
+++ b/src/gxcore/client/client-storage/common.ts
@@ -1,6 +1,6 @@
 export const keyPrefix: string = "gx.client.clientstorage";
 
-export const storage = global.localStorage;
+export { storage } from "../../../common/storage";
 
 export function prefixKey(key: string) {
   return `${keyPrefix}.${key}`;

--- a/src/gxcore/client/client-storage/common.ts
+++ b/src/gxcore/client/client-storage/common.ts
@@ -1,6 +1,6 @@
 export const keyPrefix: string = "gx.client.clientstorage";
 
-export const storage = window.localStorage;
+export const storage = global.localStorage;
 
 export function prefixKey(key: string) {
   return `${keyPrefix}.${key}`;

--- a/src/gxcore/client/client-storage/get.ts
+++ b/src/gxcore/client/client-storage/get.ts
@@ -6,7 +6,7 @@ import { prefixKey, storage } from "./common";
  * @return {string}
  */
 export function get(key: string): string {
-  let pKey = prefixKey(key);
-  let value = storage.getItem(pKey);
+  const pKey = prefixKey(key);
+  const value = storage?.getItem(pKey);
   return value || "";
 }

--- a/src/gxcore/client/client-storage/remove.ts
+++ b/src/gxcore/client/client-storage/remove.ts
@@ -5,6 +5,9 @@ import { prefixKey, storage } from "./common";
  * @param {string} key
  */
 export function remove(key: any) {
-  let pKey = prefixKey(key);
+  if (!storage) {
+    return;
+  }
+  const pKey = prefixKey(key);
   storage.removeItem(pKey);
 }

--- a/src/gxcore/client/client-storage/set.ts
+++ b/src/gxcore/client/client-storage/set.ts
@@ -7,6 +7,9 @@ import { prefixKey, storage } from "./common";
  * @param {string} value
  */
 export function set(key: string, value: string) {
-  let pKey = prefixKey(key);
+  if (!storage) {
+    return;
+  }
+  const pKey = prefixKey(key);
   storage.setItem(pKey, value);
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,0 @@
-export {};
-
-declare global {
-  namespace NodeJS {
-    interface Global extends WindowLocalStorage {}
-  }
-}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+declare global {
+  namespace NodeJS {
+    interface Global extends WindowLocalStorage {}
+  }
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

To allow this library to run in environments other than the browser, (basically Node) all instances of `window` are renamed to `global`. Also, defensively check if `localStorage` is available.

#### Testin instructions

`npm run test`

