### PR TITLE
Storage EXO usage breaks Application: Uncaught ReferenceError: global is not defined

### DIFF
--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -1,3 +1,1 @@
-const globalAny = global as any;
-
-export const storage = globalAny.localStorage;
+export const storage = globalThis.localStorage;


### PR DESCRIPTION
Any App that Uses Storage EXO, fails to load. 

```
Uncaught ReferenceError: global is not defined
    at Module.IODz (storage.js:1)
    at __webpack_require__ (bootstrap:84)
    at Module.m4nc (configurationState.js:1)
    at __webpack_require__ (bootstrap:84)
    at Module.uBgY (setLanguage.js:1)
    at __webpack_require__ (bootstrap:84)
    at Module.jfPR (gamuser.dt.ts:25)
    at __webpack_require__ (bootstrap:84)
    at Module.aKa+ (ui-message.dt.ts:25)
    at __webpack_require__ (bootstrap:84)
```

Sample:
https://angular-demo.genexus.com/playground-dev/